### PR TITLE
Add user and project login domains to keystone

### DIFF
--- a/library/keystone
+++ b/library/keystone
@@ -38,6 +38,11 @@ options:
             - login username to authenticate to keystone
         required: false
         default: admin
+    login_user_domain_name:
+        description:
+            - The domain login_user belongs to
+        required: false
+        default: None
     login_password:
         description:
             - Password of login user
@@ -46,6 +51,11 @@ options:
     login_project_name:
         description:
             - The project login_user belongs to
+        required: false
+        default: None
+    login_project_domain_name:
+        description:
+            - The domain login_project belongs to
         required: false
         default: None
     login_tenant_name:
@@ -522,6 +532,8 @@ class ManageKeystone(object):
             'login_password',
             'login_project_name',
             'login_tenant_name',
+            'login_user_domain_name',
+            'login_project_domain_name',
             'token',
             'insecure'
         ]
@@ -532,6 +544,10 @@ class ManageKeystone(object):
         login_password = variables_dict.pop('login_password')
         login_project_name = (variables_dict.pop('login_project_name', None) or
                               variables_dict.pop('login_tenant_name'))
+        user_domain_name = variables_dict.pop('login_user_domain_name',
+                                              'Default')
+        project_domain_name = variables_dict.pop('login_project_domain_name',
+                                                 'Default')
         token = variables_dict.pop('token')
         insecure = variables_dict.pop('insecure')
 
@@ -564,8 +580,10 @@ class ManageKeystone(object):
                 insecure=insecure,
                 auth_url=endpoint,
                 username=login_user,
+                user_domain_name=user_domain_name,
                 password=login_password,
-                project_name=login_project_name
+                project_name=login_project_name,
+                project_domain_name=project_domain_name,
             )
 
     def _get_domain_from_vars(self, variables):
@@ -1166,6 +1184,9 @@ def main():
             login_user=dict(
                 required=False
             ),
+            login_user_domain_name=dict(
+                required=False
+            ),
             login_password=dict(
                 required=False
             ),
@@ -1173,6 +1194,9 @@ def main():
                 required=False
             ),
             login_project_name=dict(
+                required=False
+            ),
+            login_project_domain_name=dict(
                 required=False
             ),
             token=dict(


### PR DESCRIPTION
If user or project domain is not the default ("Default") than authenticating with login_user without adding the proper domains causes the following error:

```
An exception occurred during task execution. The full traceback is:
Traceback (most recent call last):
  File "<stdin>", line 3317, in <module>
  File "<stdin>", line 1329, in main
  File "<stdin>", line 471, in command_router
  File "<stdin>", line 703, in get_user
  File "<stdin>", line 587, in _authenticate
  File "/usr/lib/python2.7/dist-packages/keystoneclient/v3/client.py", line 226, in __init__
    self.authenticate()
  File "/usr/lib/python2.7/dist-packages/positional/__init__.py", line 94, in inner
    return func(*args, **kwargs)
  File "/usr/lib/python2.7/dist-packages/keystoneclient/httpclient.py", line 584, in authenticate
    resp = self.get_raw_token_from_identity_service(**kwargs)
  File "/usr/lib/python2.7/dist-packages/keystoneclient/v3/client.py", line 301, in get_raw_token_from_identity_service
    return plugin.get_auth_ref(self.session)
  File "/usr/lib/python2.7/dist-packages/keystoneclient/auth/identity/v3/base.py", line 190, in get_auth_ref
    authenticated=False, log=False, **rkwargs)
  File "/usr/lib/python2.7/dist-packages/keystoneclient/session.py", line 520, in post
    return self.request(url, 'POST', **kwargs)
  File "/usr/lib/python2.7/dist-packages/positional/__init__.py", line 94, in inner
    return func(*args, **kwargs)
  File "/usr/lib/python2.7/dist-packages/keystoneclient/session.py", line 420, in request
    raise exceptions.from_response(resp, method, url)
keystoneauth1.exceptions.http.Unauthorized: The request you have made requires authentication. (HTTP 401) (Request-ID: req-fce34093-2501-4b39-805a-76b0cd6551e1)
```

Example (http://docs.openstack.org/mitaka/install-guide-ubuntu/keystone-users.html):

``` yaml
- keystone:
    command: ensure_domain
    endpoint: "http://{{ management_ip }}:35357/v3"
    token: "{{ keystone_admin_token }}"
    domain_name: default
    domain_enabled: True

- keystone:
    command: ensure_project
    endpoint: "http://{{ management_ip }}:35357/v3"
    token: "{{ keystone_admin_token }}"
    project_name: admin
    domain_name: default
    description: "Admin Project"                                          

-  keystone:
    command: ensure_user                                                           
    endpoint: "http://{{ management_ip }}:35357/v3"                                
    token: "{{ keystone_admin_token }}"                                            
    user_name: admin
    password: "{{ keystone_admin_password }}"                                                
    project_name: admin
    domain_name: default

- keystone:                                                                     
    command: ensure_role                                                        
    endpoint: "http://{{ management_ip }}:35357/v3"                             
    token: "{{ keystone_admin_token }}"                                         
    role_name: admin                                                     

- keystone:                                                                     
    command: ensure_user_role                                                   
    endpoint: "http://{{ management_ip }}:35357/v3"                             
    token: "{{ keystone_admin_token }}"                                         
    user_name: admin                                                
    project_name: admin                                          
    role_name: admin

- keystone:
    command: get_user
    endpoint: "http://{{ management_ip }}:35357/v3"
    login_user: admin
    login_password: "{{ keystone_admin_password }}"
    login_project_name: admin
    #login_user_domain_name: default
    #login_project_domain_name: default
    user_name: admin
```

Adding this patch and removing # characters the role runs successfully.
